### PR TITLE
Added API token to get requests

### DIFF
--- a/ping_to_netbox.py
+++ b/ping_to_netbox.py
@@ -139,13 +139,13 @@ if __name__ == '__main__':
 		print("Not currently loading addresses from RFC1918, even though I was told to!!")
 	if load_scanner_from_rfc1918_or_netbox == 2:
 		#GET IP addresses from Netbox
-		response = requests.get(ip_addresses_url)
+		response = requests.get(ip_addresses_url, headers=header)
 		listOfIpsWithMask = response.json()['results']
 		for ipaddr in listOfIpsWithMask:
 			ipaddr['isNew'] = "old"
 	if load_scanner_from_rfc1918_or_netbox == 3:
 		#GET IP prefixes from Netbox
-		response = requests.get(ip_prefixes_url)
+		response = requests.get(ip_prefixes_url, headers=header)
 		listOfPrefixes = response.json()['results']
 		print(json.dumps(listOfPrefixes, indent=4))
 		listOfIps = []


### PR DESCRIPTION
It is possible to require authentication to even view Netbox (set in configuration.py). If authentication is required then the "if load_scanner_from_rfc1918_or_netbox" logic will fail because the "response = requests.get" code will return a 403 Forbidden error code. By adding the API token to these functions it will work even if authentication is required.